### PR TITLE
Draft pr

### DIFF
--- a/hw09_struct_validator/go.mod
+++ b/hw09_struct_validator/go.mod
@@ -1,3 +1,11 @@
-module github.com/fixme_my_friend/hw09_struct_validator
+module github.com/exiffM/otus_homework/hw09_struct_validator
 
-go 1.19
+go 1.20
+
+require github.com/stretchr/testify v1.8.4
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/hw09_struct_validator/go.sum
+++ b/hw09_struct_validator/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/hw09_struct_validator/validator.go
+++ b/hw09_struct_validator/validator.go
@@ -152,9 +152,9 @@ func Validate(v interface{}) (string, error) {
 
 	for _, field := range fieldsList {
 		if param, ok := field.Tag.Lookup("validate"); ok {
-			switch field.Type.Kind() {
+			switch field.Type.Kind() { //nolint:all
 			case reflect.Slice:
-				switch field.Type.Elem().Kind() {
+				switch field.Type.Elem().Kind() { //nolint:all
 				case reflect.Int:
 					slice := rv.FieldByName(field.Name).Interface().([]int)
 					for _, elem := range slice {

--- a/hw09_struct_validator/validator.go
+++ b/hw09_struct_validator/validator.go
@@ -1,17 +1,185 @@
 package hw09structvalidator
 
+import (
+	"errors"
+	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
 type ValidationError struct {
 	Field string
 	Err   error
 }
 
+var (
+	// global errors.
+	errInvalidType     = errors.New("inserted argument is not a struct")
+	errValidationError = errors.New("validation completed with errors")
+)
+
 type ValidationErrors []ValidationError
 
 func (v ValidationErrors) Error() string {
-	panic("implement me")
+	b := strings.Builder{}
+	for _, elem := range v {
+		b.WriteString(elem.Field + "-->" + elem.Err.Error() + "\n")
+	}
+
+	return b.String()
 }
 
-func Validate(v interface{}) error {
-	// Place your code here.
-	return nil
+func validateInt(key, field string, value int, ve *ValidationErrors) {
+	keys := strings.Split(key, "|")
+	for _, k := range keys {
+		subkeys := strings.Split(k, ":")
+		switch subkeys[0] {
+		case "min":
+			res, err := strconv.Atoi(subkeys[1])
+			if err != nil {
+				*ve = append(*ve, ValidationError{
+					Field: field,
+					Err:   errors.New("invalid key value, key min=" + subkeys[1]),
+				})
+			} else if value < res {
+				*ve = append(*ve, ValidationError{
+					Field: field,
+					Err:   errors.New("invalid value, ocured value is less than min=" + subkeys[1]),
+				})
+			}
+		case "max":
+			res, err := strconv.Atoi(subkeys[1])
+			if err != nil {
+				*ve = append(*ve, ValidationError{
+					Field: field,
+					Err:   errors.New("invalid key value, key max=" + subkeys[1]),
+				})
+			} else if value > res {
+				*ve = append(*ve, ValidationError{
+					Field: field,
+					Err:   errors.New("invalid value, ocured value is greater than max=" + subkeys[1]),
+				})
+			}
+		case "in":
+			values := strings.Split(subkeys[1], ",")
+			found := false
+			for _, v := range values {
+				res, err := strconv.Atoi(v)
+				if err != nil {
+					*ve = append(*ve, ValidationError{
+						Field: field,
+						Err:   errors.New("invalid key value, key in=" + v),
+					})
+				} else if res == value {
+					found = true
+					break
+				}
+			}
+			if !found {
+				*ve = append(*ve, ValidationError{
+					Field: field,
+					Err:   errors.New("invalid value, value is not in \"in\" list"),
+				})
+			}
+		default:
+			*ve = append(*ve, ValidationError{
+				Field: field,
+				Err:   errors.New("invalid validate subtag"),
+			})
+		}
+	}
+}
+
+func validateString(key, field, value string, ve *ValidationErrors) {
+	keys := strings.Split(key, "|")
+	for _, k := range keys {
+		subkeys := strings.Split(k, ":")
+		switch subkeys[0] {
+		case "len":
+			res, err := strconv.Atoi(subkeys[1])
+			if err != nil {
+				*ve = append(*ve, ValidationError{
+					Field: field,
+					Err:   errors.New("invalid key value, key len=" + subkeys[1]),
+				})
+			} else if len(value) != res {
+				*ve = append(*ve, ValidationError{
+					Field: field,
+					Err:   errors.New("invalid value, value's length is greater than len=" + subkeys[1]),
+				})
+			}
+		case "regexp":
+			rx, err := regexp.Compile(subkeys[1])
+			if err != nil {
+				*ve = append(*ve, ValidationError{
+					Field: field,
+					Err:   errors.New("invalid key value, key regexp = " + subkeys[1]),
+				})
+			} else {
+				res := rx.FindString(value)
+				if res != value {
+					*ve = append(*ve, ValidationError{
+						Field: field,
+						Err:   errors.New("invalid value, value doesn't match regular expression"),
+					})
+				}
+			}
+		case "in":
+			if !strings.Contains(subkeys[1], value) {
+				*ve = append(*ve, ValidationError{
+					Field: field,
+					Err:   errors.New("invalid value, value is not in \"in\" list"),
+				})
+			}
+		default:
+			*ve = append(*ve, ValidationError{
+				Field: field,
+				Err:   errors.New("invalid validate subtag"),
+			})
+		}
+	}
+}
+
+func Validate(v interface{}) (string, error) {
+	ve := ValidationErrors{}
+	rv := reflect.ValueOf(v)
+	if rv.Kind() != reflect.Struct {
+		return ve.Error(), errInvalidType
+	}
+
+	fieldsList := reflect.VisibleFields(rv.Type())
+
+	for _, field := range fieldsList {
+		if param, ok := field.Tag.Lookup("validate"); ok {
+			switch field.Type.Kind() {
+			case reflect.Slice:
+				switch field.Type.Elem().Kind() {
+				case reflect.Int:
+					slice := rv.FieldByName(field.Name).Interface().([]int)
+					for _, elem := range slice {
+						validateInt(param, field.Name, elem, &ve)
+					}
+				case reflect.String:
+					slice := rv.FieldByName(field.Name).Interface().([]string)
+					for _, elem := range slice {
+						validateString(param, field.Name, elem, &ve)
+					}
+				default:
+					ve = append(ve, ValidationError{Field: field.Name, Err: errors.New("unknown slice field type")})
+				}
+			case reflect.Int:
+				validateInt(param, field.Name, rv.FieldByName(field.Name).Interface().(int), &ve)
+			case reflect.String:
+				validateString(param, field.Name, rv.FieldByName(field.Name).Interface().(string), &ve)
+			default:
+				ve = append(ve, ValidationError{Field: field.Name, Err: errors.New("unknown field type")})
+			}
+		}
+	}
+
+	if len(ve) > 0 {
+		return ve.Error(), errValidationError
+	}
+	return ve.Error(), nil
 }

--- a/hw09_struct_validator/validator_test.go
+++ b/hw09_struct_validator/validator_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 type UserRole string
@@ -15,7 +17,7 @@ type (
 		Name   string
 		Age    int             `validate:"min:18|max:50"`
 		Email  string          `validate:"regexp:^\\w+@\\w+\\.\\w+$"`
-		Role   UserRole        `validate:"in:admin,stuff"`
+		Role   string          `validate:"in:admin,stuff"`
 		Phones []string        `validate:"len:11"`
 		meta   json.RawMessage //nolint:unused
 	}
@@ -34,27 +36,123 @@ type (
 		Code int    `validate:"in:200,404,500"`
 		Body string `json:"omitempty"`
 	}
+	ExtraStruct struct {
+		ArifmeticVals []int  `validate:"max:7"`          // should be ok
+		NotInSet      string `validate:"in:bar,foo,D12"` // not in set
+		NotAccordMin  int    `validate:"min:9"`          // will be 5
+		NotAccordMax  int    `validate:"max:9"`          // will be 10
+	}
+	InvalidTags struct {
+		BadRegexp string `validate:"len:5zc|regexp:a(*"` // bad regexp and incorrect len
+		BadVal    int    `validate:"min:4rt|max:6u"`     // incorrect tag values
+		BadTag    string `validate:"lan:10"`             // bad tag
+		BadInTag  int    `validate:"in:7,5,g10"`
+		BadMaxTag int    `validate:"maxf:15"`
+	}
+	UnknownTypes struct {
+		wideCharacters []rune  `validate:"max:10"`
+		radius         float64 `validate:"in:3.14,6.28,14.2"`
+	}
 )
 
 func TestValidate(t *testing.T) {
 	tests := []struct {
-		in          interface{}
-		expectedErr error
+		name                     string
+		in                       interface{}
+		expectedErr              error
+		expectedValidationErrors string
 	}{
 		{
-			// Place your code here.
+			name:                     "int",
+			in:                       10,
+			expectedErr:              errInvalidType,
+			expectedValidationErrors: "",
 		},
-		// ...
-		// Place your code here.
+		{
+			name: "ExtraStruct",
+			in: ExtraStruct{
+				ArifmeticVals: []int{1, 2, 3, 4, 5},
+				NotInSet:      "any",
+				NotAccordMin:  5,
+				NotAccordMax:  10,
+			},
+			expectedErr: errValidationError,
+			expectedValidationErrors: "NotInSet-->invalid value, value is not in \"in\" list\n" +
+				"NotAccordMin-->invalid value, ocured value is less than min=9\n" +
+				"NotAccordMax-->invalid value, ocured value is greater than max=9\n",
+		},
+		{
+			name: "InvalidTags",
+			in: InvalidTags{
+				BadRegexp: "any string",
+				BadVal:    155,
+				BadTag:    "any",
+				BadInTag:  10,
+				BadMaxTag: 15,
+			},
+			expectedErr: errValidationError,
+			expectedValidationErrors: "BadRegexp-->invalid key value, key len=5zc\n" +
+				"BadRegexp-->invalid key value, key regexp = a(*\n" +
+				"BadVal-->invalid key value, key min=4rt\n" +
+				"BadVal-->invalid key value, key max=6u\n" +
+				"BadTag-->invalid validate subtag\n" +
+				"BadInTag-->invalid key value, key in=g10\n" +
+				"BadInTag-->invalid value, value is not in \"in\" list\n" +
+				"BadMaxTag-->invalid validate subtag\n",
+		},
+		{
+			name: "Response",
+			in: Response{
+				Code: 200,
+				Body: "Any body",
+			},
+			expectedErr:              nil,
+			expectedValidationErrors: "",
+		},
+		{
+			name: "User",
+			in: User{
+				ID:     "43257405nfyelfyr6493jfy936781130ik",
+				Name:   "Any name",
+				Age:    16,
+				Email:  "somemaildomenyanix.ru",
+				Role:   "admin",
+				Phones: []string{"281-330-800", "1-800-nmber"},
+			},
+			expectedErr: errValidationError,
+			expectedValidationErrors: "ID-->invalid value, value's length is greater than len=36\n" +
+				"Age-->invalid value, ocured value is less than min=18\n" +
+				"Email-->invalid value, value doesn't match regular expression\n",
+		},
+		{
+			name: "Token",
+			in: Token{
+				Header:    []byte{'c', '1', 'b'},
+				Payload:   []byte{'p', 'a', 'y'},
+				Signature: []byte{'b', 'y', 't', 'e', 's'},
+			},
+			expectedErr:              nil,
+			expectedValidationErrors: "",
+		},
+		{
+			name: "UnknownTypes",
+			in: UnknownTypes{
+				wideCharacters: []rune{432, 123, 654},
+				radius:         3.14,
+			},
+			expectedErr:              errValidationError,
+			expectedValidationErrors: "wideCharacters-->unknown slice field type\nradius-->unknown field type\n",
+		},
 	}
 
 	for i, tt := range tests {
-		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
+		t.Run(fmt.Sprintf("case %d %v", i, tt.name), func(t *testing.T) {
 			tt := tt
 			t.Parallel()
 
-			// Place your code here.
-			_ = tt
+			errorStr, err := Validate(tt.in)
+			require.ErrorIs(t, err, tt.expectedErr, "Errors missmatch. Actual error is %v", err)
+			require.Equal(t, tt.expectedValidationErrors, errorStr, "Errors missmatch. Actual errors are %v", errorStr)
 		})
 	}
 }


### PR DESCRIPTION
Возник впрос по линтеру опять.
validator.go:155:4: missing cases in switch of type reflect.Kind: reflect.Invalid, reflect.Bool, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr, reflect.Float32, reflect.Float64, reflect.Complex64, reflect.Complex128, reflect.Array, reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer|reflect.Ptr, reflect.Struct, reflect.UnsafePointer (exhaustive)
                        switch field.Type.Kind() {
                        ^
Линтер выдает такую ошибку, хотя в обоих контсрукциях switch есть ветка default. Ошибка линтера возникает для обоих кейсов. Действительно ли необходимо расписывать каждый кейс для перечисления типов из пакета reflect?