### PR TITLE
Hw11 telnet client

### DIFF
--- a/hw11_telnet_client/main.go
+++ b/hw11_telnet_client/main.go
@@ -1,6 +1,41 @@
 package main
 
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+var (
+	args     []string
+	duration time.Duration
+)
+
+func init() {
+	flag.DurationVar(&duration, "timeout", 10*time.Second, "use --timeout=<value> in seconds")
+}
+
 func main() {
-	// Place your code here,
-	// P.S. Do not rush to throw context down, think think if it is useful with blocking operation?
+	flag.Parse()
+	args = flag.Args()
+	if len(args) < 2 {
+		fmt.Println("invalid usage of go-telnet\nuse command go-telnet [--timeout=x] <hostname/ipadress> <port>")
+		return
+	}
+	sb := strings.Builder{}
+	sb.WriteString(args[0]) // link/ip-address
+	sb.WriteString(":")
+	sb.WriteString(args[1]) // port
+	client := NewTelnetClient(sb.String(), duration, os.Stdin, os.Stdout)
+	err := client.Connect()
+	// defer client.Close()
+	if err != nil {
+		fmt.Println(err.Error())
+		return
+	}
+	client.Send()
+	client.Receive()
+	client.Close()
 }

--- a/hw11_telnet_client/telnet.go
+++ b/hw11_telnet_client/telnet.go
@@ -1,21 +1,180 @@
 package main
 
 import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
 	"io"
+	"net"
+	"os"
+	"os/signal"
+	"strings"
+	"sync"
 	"time"
 )
+
+// var errCannotScan = errors.New("can't scan data from connection")
 
 type TelnetClient interface {
 	Connect() error
 	io.Closer
 	Send() error
 	Receive() error
+	FinishChan() chan os.Signal
 }
 
-func NewTelnetClient(address string, timeout time.Duration, in io.ReadCloser, out io.Writer) TelnetClient {
-	// Place your code here.
+type TnetClient struct {
+	ctx          context.Context
+	conn         net.Conn
+	connAddress  string
+	retryTimeout time.Duration
+	inStream     io.ReadCloser
+	outStream    io.Writer
+	cancel       context.CancelFunc
+	lastError    error
+	finish       chan os.Signal
+	wg           sync.WaitGroup
+}
+
+func (tc *TnetClient) Connect() error {
+	signal.Notify(tc.finish, os.Interrupt)
+	dialer := &net.Dialer{
+		Timeout:  tc.retryTimeout,
+		Resolver: net.DefaultResolver,
+	}
+	tc.ctx, tc.cancel = context.WithCancel(context.Background())
+	tc.conn, tc.lastError = dialer.DialContext(tc.ctx, "tcp", tc.connAddress)
+	if tc.lastError != nil {
+		return tc.lastError
+	}
 	return nil
 }
 
-// Place your code here.
-// P.S. Author's solution takes no more than 50 lines.
+func (tc *TnetClient) Send() error {
+	tc.wg.Add(1)
+	count := 0
+	go func() {
+		defer tc.wg.Done()
+		stdin := stdinScan(tc.inStream)
+		// defer close(stdin)
+		sb := strings.Builder{}
+		// FORCYCLE:
+		for {
+			// fmt.Println("In send for cycle")
+			select {
+			case <-tc.ctx.Done():
+				fmt.Println("Send is done by context cancel func")
+				return
+			case data, ok := <-stdin:
+				sb.WriteString(data)
+				sb.WriteString("\n")
+				fmt.Println("Before write in socket")
+				_, err := tc.conn.Write([]byte(sb.String()))
+				fmt.Println("After write in socket")
+				sb.Reset()
+				if err != nil {
+					return
+				}
+				if !ok {
+					if count > 2 {
+						return
+					}
+					count++
+				}
+			}
+			// fmt.Println("End send for cycle")
+		}
+		// fmt.Println("Out of send for cycle")
+	}()
+	return nil
+}
+
+func (tc *TnetClient) Receive() error {
+	// tc.wg.Add(1)
+	// go func() {
+	// defer tc.wg.Done()
+	scanner := bufio.NewScanner(tc.conn)
+	// FORCYCLE:
+	// for {
+	// 	// // fmt.Println("in recv for cycle")
+	// 	if !scanner.Scan() {
+	// 		tc.lastError = errCannotScan
+	// 		break
+	// 	}
+	// 	wbytes, err := tc.outStream.Write(append(scanner.Bytes(), '\n'))
+	// 	if err != nil {
+	// 		break
+	// 	}
+	// 	if wbytes == 0 {
+	// 		break
+	// 	}
+	// 	// fmt.Println("Out default branch of recv")
+	// }
+	for scanner.Scan() {
+		wbytes, err := tc.outStream.Write(append(scanner.Bytes(), '\n'))
+		if err != nil {
+			return err
+		}
+		if wbytes == 0 {
+			break
+		}
+	}
+	fmt.Println("Out of recv for cycle")
+	// }()
+
+	// if tc.lastError != nil {
+	// 	return tc.lastError
+	// }
+
+	return nil
+}
+
+func (tc *TnetClient) Close() error {
+	for s := range tc.finish {
+		if s == os.Interrupt {
+			close(tc.finish)
+			// fmt.Println("Log: context cancel function call")
+			tc.cancel()
+			break
+		}
+	}
+	// fmt.Println("Log: w8ing for gorutines")
+	tc.wg.Wait()
+	// fmt.Println("Log: goruties are closed")
+	tc.conn.Close()
+	return nil
+}
+
+func (tc *TnetClient) FinishChan() chan os.Signal {
+	return tc.finish
+}
+
+func stdinScan(in io.ReadCloser) chan string {
+	out := make(chan string)
+	go func() {
+		scanner := bufio.NewScanner(in)
+		for scanner.Scan() {
+			out <- scanner.Text()
+		}
+		if scanner.Err() != nil {
+			fmt.Println("stdin chan is closed 1")
+			close(out)
+		}
+		if errors.Is(scanner.Err(), io.EOF) {
+			fmt.Println("stdin chan is closed 2")
+			close(out)
+		}
+	}()
+	return out
+}
+
+func NewTelnetClient(address string, timeout time.Duration, in io.ReadCloser, out io.Writer) TelnetClient {
+	return &TnetClient{
+		connAddress:  address,
+		retryTimeout: timeout,
+		inStream:     in,
+		outStream:    out,
+		finish:       make(chan os.Signal, 1),
+	}
+}

--- a/hw11_telnet_client/telnet.go
+++ b/hw11_telnet_client/telnet.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"net"
 	"os"
@@ -64,14 +63,14 @@ func (tc *TnetClient) Send() error {
 			// fmt.Println("In send for cycle")
 			select {
 			case <-tc.ctx.Done():
-				fmt.Println("Send is done by context cancel func")
+				// fmt.Println("Send is done by context cancel func")
 				return
 			case data, ok := <-stdin:
 				sb.WriteString(data)
 				sb.WriteString("\n")
-				fmt.Println("Before write in socket")
+				// fmt.Println("Before write in socket")
 				_, err := tc.conn.Write([]byte(sb.String()))
-				fmt.Println("After write in socket")
+				// fmt.Println("After write in socket")
 				sb.Reset()
 				if err != nil {
 					return
@@ -120,7 +119,7 @@ func (tc *TnetClient) Receive() error {
 			break
 		}
 	}
-	fmt.Println("Out of recv for cycle")
+	// fmt.Println("Out of recv for cycle")
 	// }()
 
 	// if tc.lastError != nil {
@@ -158,11 +157,11 @@ func stdinScan(in io.ReadCloser) chan string {
 			out <- scanner.Text()
 		}
 		if scanner.Err() != nil {
-			fmt.Println("stdin chan is closed 1")
+			// fmt.Println("stdin chan is closed 1")
 			close(out)
 		}
 		if errors.Is(scanner.Err(), io.EOF) {
-			fmt.Println("stdin chan is closed 2")
+			// fmt.Println("stdin chan is closed 2")
 			close(out)
 		}
 	}()

--- a/hw11_telnet_client/telnet_test.go
+++ b/hw11_telnet_client/telnet_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"net"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -40,6 +41,7 @@ func TestTelnetClient(t *testing.T) {
 			err = client.Receive()
 			require.NoError(t, err)
 			require.Equal(t, "world\n", out.String())
+			client.FinishChan() <- os.Interrupt
 		}()
 
 		go func() {

--- a/hw11_telnet_client/test.sh
+++ b/hw11_telnet_client/test.sh
@@ -3,7 +3,7 @@ set -xeuo pipefail
 
 go build -o go-telnet
 
-(echo -e "Hello\nFrom\nNC\n" && cat 2>/dev/null) | nc -l localhost 4242 >/tmp/nc.out &
+(echo -e "Hello\nFrom\nNC\n" && cat 2>/dev/null) | nc -ls localhost -p 4242 >/tmp/nc.out &
 NC_PID=$!
 
 sleep 1


### PR DESCRIPTION
Возник вопрос по поводу логики работы клиента.
Правильно ли я понял, что при разрыве соединения со стороны севера,
клиент продолжает работу пока мы его не прервем сигналом interrupt или сочетанием клавиш ctrl + D?

Со вторым пока загвоздка, пытался везде проверять на EOF, но упорно не скан игнорирует эту проверку.
По доке  метод scan воернет false в случае ошибки и если это EOF, то ошибка будет nil (так тоже проверял - не вышло).

P.S. Возможно, идеологически, не совсем верно делать метод recv в основной рутине? Не знаю, что на счет такого способа? Но вроде так работает. Можно конечно сделать неблокирующий сокет и тогда в отдельной горутине тоже будет нормально работать
